### PR TITLE
test(backend): speed up checker test by ~4s

### DIFF
--- a/test/integration/monitors/to-service/checker.test.js
+++ b/test/integration/monitors/to-service/checker.test.js
@@ -70,31 +70,14 @@ describe('healthcheck checker', () => {
     });
   });
 
-  test('should timeout if it takes too long to receive a response', (done) => {
-    server.get('/', (req, res) => {
-      setTimeout(() => {
-        res.send('hi');
-      }, 5000);
-    });
-
-    checker({ url: BASE }).then((resp) => {
-      expect(resp.error).toBeDefined();
-      expect(resp.error.code).toBe('ESOCKETTIMEDOUT');
-      expect(resp.body).toBeUndefined();
-      expect(resp.responseTime).toBeUndefined();
-      expect(resp.statusCode).toBeUndefined();
-      done();
-    });
-  });
-
   test('should timeout if it takes longer than specified', (done) => {
     server.get('/', (req, res) => {
       setTimeout(() => {
         res.send('hi');
-      }, 1500);
+      }, 250);
     });
 
-    checker({ url: BASE, timeoutSeconds: 1 }).then((resp) => {
+    checker({ url: BASE, timeoutSeconds: 0.2 }).then((resp) => {
       expect(resp.error).toBeDefined();
       expect(resp.error.code).toBe('ESOCKETTIMEDOUT');
       expect(resp.body).toBeUndefined();


### PR DESCRIPTION
Previously the `checker` test was taking 4-5+s to run because it ensured the default timeout and a specified timeout of 1s worked.

This quickly became annoying once the githooks were merged, because who wants to:

- commit
- wait 5s for tests
- push
- wait 5s for tests

This change removes the default timeout test entirely and greatly reduces the specified timeout in the other test.