### PR TITLE
Notification Base

### DIFF
--- a/src/monitors/to-service/bootstrap.js
+++ b/src/monitors/to-service/bootstrap.js
@@ -1,5 +1,6 @@
 const checker = require('./checker');
 const determineHealth = require('./determineHealth');
+const notifications = require('./../../notifications');
 
 const intervals = {};
 
@@ -7,7 +8,8 @@ const checkMonitor = monitor => () => {
   console.log('checking to-service', monitor.id);
   checker(monitor.request).then((data) => {
     console.log('checked to-service', monitor.id, data);
-    determineHealth(monitor, data);
+    const event = determineHealth(monitor, data);
+    notifications.log(monitor, event);
   });
 };
 

--- a/src/monitors/to-service/determineHealth.js
+++ b/src/monitors/to-service/determineHealth.js
@@ -1,6 +1,9 @@
 const ruleParser = require('./rules');
 
-const assertNoError = data => data.error === null;
+const assertNoError = {
+  test: data => data.error === null,
+  text: data => `error ${data.error === null ? 'is' : 'is not'} null`,
+};
 
 module.exports = (monitor, data) => {
   const rules = [
@@ -8,7 +11,7 @@ module.exports = (monitor, data) => {
     ...ruleParser.mapRules(monitor.rules || []),
   ];
 
-  const healthy = rules.every(rule => rule(data));
+  const healthy = rules.every(rule => rule.test(data));
 
   console.log(monitor.id, 'healthy?', healthy ? 'yes' : 'no');
 

--- a/src/monitors/to-service/determineHealth.js
+++ b/src/monitors/to-service/determineHealth.js
@@ -5,15 +5,28 @@ const assertNoError = {
   text: data => `error ${data.error === null ? 'is' : 'is not'} null`,
 };
 
+const makeVerboseRules = (rules, data) => rules.map(rule => ({
+  passed: rule.test(data),
+  text: rule.text(data),
+}));
+
 module.exports = (monitor, data) => {
   const rules = [
     assertNoError,
     ...ruleParser.mapRules(monitor.rules || []),
   ];
 
-  const healthy = rules.every(rule => rule.test(data));
+  const actions = makeVerboseRules(rules, data);
+  const healthy = actions.every(action => action.passed);
+
+  const event = {
+    type: 'to-service',
+    healthy,
+    time: (new Date()).getTime(),
+    actions,
+  };
 
   console.log(monitor.id, 'healthy?', healthy ? 'yes' : 'no');
 
-  return healthy;
+  return event;
 };

--- a/src/monitors/to-service/rules/index.js
+++ b/src/monitors/to-service/rules/index.js
@@ -5,10 +5,23 @@ module.exports.mapRule = ({ type, operator, value }) => {
   const rule = rules[type];
   const ruleOperator = operators[operator];
 
-  return data => ruleOperator(
-    rule(data),
-    value,
-  );
+  return {
+    test: data => ruleOperator(
+      rule(data),
+      value,
+    ),
+    text: (data) => {
+      const current = rule(data);
+      const expected = value;
+
+      const truth = ruleOperator(current, expected);
+      const ruleText = truth
+        ? ruleOperator.trueText
+        : ruleOperator.falseText;
+
+      return `${type} of ${current} ${ruleText} ${expected}`;
+    },
+  };
 };
 
 // deserialize monitor rules into truth functions

--- a/src/monitors/to-service/rules/operators.js
+++ b/src/monitors/to-service/rules/operators.js
@@ -1,10 +1,30 @@
 const eq = (a, b) => a === b;
+eq.trueText = 'is equal to';
+eq.falseText = 'is not equal to';
+
 const lt = (a, b) => a < b;
+lt.trueText = 'is less than';
+lt.falseText = 'is not less than';
+
 const lte = (a, b) => a <= b;
+lte.trueText = 'is less than or equal to';
+lte.falseText = 'is not less than or equal to';
+
 const gt = (a, b) => a > b;
+gt.trueText = 'is greater than';
+gt.falseText = 'is not greater than';
+
 const gte = (a, b) => a >= b;
+gte.trueText = 'is greater than or equal to';
+gte.falseText = 'is not greater than or equal to';
+
 const not = (a, b) => a !== b;
+not.trueText = 'is not equal to and should not be';
+not.falseText = 'is equal to but should not be';
+
 const contains = (a, b) => a.indexOf(b) > -1;
+contains.trueText = 'contains';
+contains.falseText = 'does not contain';
 
 module.exports = {
   eq,

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -1,5 +1,4 @@
 const EventEmitter = require('events');
-const repository = require('./../monitors/repository');
 
 const emitter = new EventEmitter();
 
@@ -8,7 +7,7 @@ module.exports = {
   log: (monitor, event) => {
     console.log('got event', monitor, event);
 
-    const localMonitor = monitor;
+    const localMonitor = monitor; // stops eslint from crying
 
     if (!monitor.initialized && event.healthy) {
       localMonitor.initialized = true;
@@ -17,21 +16,18 @@ module.exports = {
         monitor,
         event,
       });
-      repository.upsertGraph(localMonitor);
     } else if (!monitor.healthy && event.healthy) {
       localMonitor.healthy = true;
       emitter.emit('healthy', {
         monitor,
         event,
       });
-      repository.upsertGraph(localMonitor);
     } else if (monitor.healthy && !event.healthy) {
       localMonitor.healthy = false;
       emitter.emit('unhealthy', {
         monitor,
         event,
       });
-      repository.upsertGraph(localMonitor);
     }
   },
 };

--- a/src/notifications/index.js
+++ b/src/notifications/index.js
@@ -1,0 +1,37 @@
+const EventEmitter = require('events');
+const repository = require('./../monitors/repository');
+
+const emitter = new EventEmitter();
+
+module.exports = {
+  emitter,
+  log: (monitor, event) => {
+    console.log('got event', monitor, event);
+
+    const localMonitor = monitor;
+
+    if (!monitor.initialized && event.healthy) {
+      localMonitor.initialized = true;
+      localMonitor.healthy = true;
+      emitter.emit('initialized', {
+        monitor,
+        event,
+      });
+      repository.upsertGraph(localMonitor);
+    } else if (!monitor.healthy && event.healthy) {
+      localMonitor.healthy = true;
+      emitter.emit('healthy', {
+        monitor,
+        event,
+      });
+      repository.upsertGraph(localMonitor);
+    } else if (monitor.healthy && !event.healthy) {
+      localMonitor.healthy = false;
+      emitter.emit('unhealthy', {
+        monitor,
+        event,
+      });
+      repository.upsertGraph(localMonitor);
+    }
+  },
+};

--- a/src/notifications/notificationDebug.js
+++ b/src/notifications/notificationDebug.js
@@ -1,0 +1,13 @@
+module.exports = (emitter) => {
+  emitter.on('initialized', ({ monitor, event }) => {
+    console.log('monitor initalized!', monitor, event);
+  });
+
+  emitter.on('healthy', ({ monitor, event }) => {
+    console.log('monitor became healthy!', monitor, event);
+  });
+
+  emitter.on('unhealthy', ({ monitor, event }) => {
+    console.log('monitor became unhealthy!', monitor, event);
+  });
+};

--- a/src/notifications/providers/index.js
+++ b/src/notifications/providers/index.js
@@ -1,0 +1,22 @@
+const webhook = require('./webhook');
+const slack = require('./slack');
+
+const providers = {
+  webhooks: webhook,
+  slack,
+};
+
+module.exports.mapNotification = ({ type, value }) => providers[type](value);
+
+module.exports.mapNotifications = (notifications) => {
+  const mappedNotifications = [];
+
+  Object.entries(notifications).forEach(([type, values]) => {
+    values.forEach((value) => {
+      const mappedNotification = module.exports.mapNotification({ type, value });
+      mappedNotifications.push(mappedNotification);
+    });
+  });
+
+  return mappedNotifications;
+};

--- a/src/notifications/providers/slack.js
+++ b/src/notifications/providers/slack.js
@@ -1,0 +1,23 @@
+const checker = require('./../../monitors/to-service/checker');
+
+module.exports = url => (type, { monitor, event }) => {
+  const title = `${monitor.name} is ${type}!`;
+
+  const attachments = event.actions.map(action => ({
+    color: action.passed ? 'good' : 'danger',
+    fallback: action.text,
+    text: action.text,
+  }));
+
+  return checker({
+    url,
+    method: 'POST',
+    body: JSON.stringify({
+      text: title,
+      attachments,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};

--- a/src/notifications/providers/webhook.js
+++ b/src/notifications/providers/webhook.js
@@ -1,0 +1,21 @@
+const checker = require('./../../monitors/to-service/checker');
+
+const sendWebhook = (url, data) => {
+  console.log('notifying', url);
+  return checker({
+    method: 'POST',
+    url,
+    body: JSON.stringify(data),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};
+
+module.exports = url => (type, data) => sendWebhook(
+  url,
+  {
+    ...data,
+    type,
+  },
+);

--- a/src/notifications/saveToRepository.js
+++ b/src/notifications/saveToRepository.js
@@ -1,0 +1,14 @@
+const repository = require('./../monitors/repository');
+
+const save = ({ monitor }) => {
+  repository.upsertGraph(monitor);
+};
+
+// listen for events emitted by the notification manager
+// when we receive them, save changed monitor state into db
+// decouples notification manager from db
+module.exports = (emitter) => {
+  emitter.on('initialized', save);
+  emitter.on('healthy', save);
+  emitter.on('unhealthy', save);
+};

--- a/src/notifications/sendNotifications.js
+++ b/src/notifications/sendNotifications.js
@@ -1,0 +1,14 @@
+const providers = require('./providers');
+
+const sendNotifications = type => (data) => {
+  const { monitor } = data;
+  const mappedNotifications = providers.mapNotifications(monitor.notifications || {});
+
+  mappedNotifications.forEach(n => n(type, data));
+};
+
+module.exports = (emitter) => {
+  emitter.on('initialized', sendNotifications('initialized'));
+  emitter.on('healthy', sendNotifications('healthy'));
+  emitter.on('unhealthy', sendNotifications('unhealthy'));
+};

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,14 +1,19 @@
 const repository = require('./monitors/repository');
 const bootstrapToService = require('./monitors/to-service/bootstrap');
 const repositoryDebug = require('./monitors/repositoryDebug');
+const notifications = require('./notifications');
+const notificationDebug = require('./notifications/notificationDebug');
 
 bootstrapToService(repository.emitter);
 repositoryDebug(repository.emitter);
+notificationDebug(notifications.emitter);
 
 // insert test monitor
 repository.upsertGraph({
   name: 'test monitor',
   type: 'to-service',
+  initialized: false, // if monitor was ever healhy
+  healthy: false, // current health state
   interval: 30,
   request: {
     url: 'http://albinodrought.com',

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,12 +1,16 @@
 const repository = require('./monitors/repository');
 const bootstrapToService = require('./monitors/to-service/bootstrap');
 const repositoryDebug = require('./monitors/repositoryDebug');
+
 const notifications = require('./notifications');
 const notificationDebug = require('./notifications/notificationDebug');
+const notificationSaveToRepo = require('./notifications/saveToRepository');
 
 bootstrapToService(repository.emitter);
 repositoryDebug(repository.emitter);
+
 notificationDebug(notifications.emitter);
+notificationSaveToRepo(notifications.emitter);
 
 // insert test monitor
 repository.upsertGraph({

--- a/src/runner.js
+++ b/src/runner.js
@@ -5,12 +5,14 @@ const repositoryDebug = require('./monitors/repositoryDebug');
 const notifications = require('./notifications');
 const notificationDebug = require('./notifications/notificationDebug');
 const notificationSaveToRepo = require('./notifications/saveToRepository');
+const notificationsSend = require('./notifications/sendNotifications');
 
 bootstrapToService(repository.emitter);
 repositoryDebug(repository.emitter);
 
 notificationDebug(notifications.emitter);
 notificationSaveToRepo(notifications.emitter);
+notificationsSend(notifications.emitter);
 
 // insert test monitor
 repository.upsertGraph({

--- a/test/integration/notifications/providers/slack.test.js
+++ b/test/integration/notifications/providers/slack.test.js
@@ -1,0 +1,61 @@
+const express = require('express');
+const slack = require('./../../../../src/notifications/providers/slack');
+
+const HOST = 'localhost';
+const PORT = 10086;
+const BASE = `http://${HOST}:${PORT}`;
+
+describe('slack notification provider', () => {
+  let server;
+  let socket;
+
+  beforeEach((done) => {
+    server = express();
+
+    socket = server.listen(PORT, done);
+  });
+
+  afterEach((done) => {
+    if (socket) {
+      socket.close(done);
+    }
+
+    server = undefined;
+    socket = undefined;
+  });
+
+  test('kitchen sink', (done) => {
+    server.use(express.json());
+    server.post('/services/OOGA/BOOGA/BOOGITY', (req, res) => {
+      expect(req.body).toEqual({
+        text: 'test-monitor is unhealthy!',
+        attachments: [
+          {
+            color: 'good',
+            fallback: 'error is null',
+            text: 'error is null',
+          },
+          {
+            color: 'danger',
+            fallback: 'responseCode is not equal to 200',
+            text: 'responseCode is not equal to 200',
+          },
+        ],
+      });
+      res.send('', 204);
+    });
+
+    slack(`${BASE}/services/OOGA/BOOGA/BOOGITY`)('unhealthy', {
+      monitor: { name: 'test-monitor' },
+      event: {
+        actions: [
+          { passed: true, text: 'error is null' },
+          { passed: false, text: 'responseCode is not equal to 200' },
+        ],
+      },
+    }).then(({ statusCode }) => {
+      expect(statusCode).toBe(204);
+      done();
+    });
+  });
+});

--- a/test/integration/notifications/providers/webhook.test.js
+++ b/test/integration/notifications/providers/webhook.test.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const webhook = require('./../../../../src/notifications/providers/webhook');
+
+const HOST = 'localhost';
+const PORT = 10087;
+const BASE = `http://${HOST}:${PORT}`;
+
+describe('slack notification provider', () => {
+  let server;
+  let socket;
+
+  beforeEach((done) => {
+    server = express();
+
+    socket = server.listen(PORT, done);
+  });
+
+  afterEach((done) => {
+    if (socket) {
+      socket.close(done);
+    }
+
+    server = undefined;
+    socket = undefined;
+  });
+
+  test('kitchen sink', (done) => {
+    server.use(express.json());
+    server.post('/webhook', (req, res) => {
+      expect(req.body).toEqual({
+        monitor: { name: 'test-monitor' },
+        event: {
+          actions: [
+            { passed: true, text: 'error is null' },
+            { passed: false, text: 'responseCode is not equal to 200' },
+          ],
+        },
+        type: 'unhealthy',
+      });
+      res.send('', 204);
+    });
+
+    webhook(`${BASE}/webhook`)('unhealthy', {
+      monitor: { name: 'test-monitor' },
+      event: {
+        actions: [
+          { passed: true, text: 'error is null' },
+          { passed: false, text: 'responseCode is not equal to 200' },
+        ],
+      },
+    }).then(({ statusCode }) => {
+      expect(statusCode).toBe(204);
+      done();
+    });
+  });
+});

--- a/test/unit/monitor/to-service/determineHealth.test.js
+++ b/test/unit/monitor/to-service/determineHealth.test.js
@@ -73,7 +73,7 @@ describe('to-service determineHealth', () => {
 
   checks.forEach(({ monitor, data, pass }, i) => {
     test(`check #${i} should ${pass ? 'pass' : 'fail'}`, () => {
-      expect(determineHealth(monitor, data)).toBe(pass);
+      expect(determineHealth(monitor, data).healthy).toBe(pass);
     });
   });
 });

--- a/test/unit/monitor/to-service/rules/index.test.js
+++ b/test/unit/monitor/to-service/rules/index.test.js
@@ -31,7 +31,7 @@ describe('to-service ruleparser', () => {
         type,
         operator,
         value,
-      })(sampleObject)).toBe(true);
+      }).test(sampleObject)).toBe(true);
     });
   });
 
@@ -41,7 +41,7 @@ describe('to-service ruleparser', () => {
         type,
         operator,
         value,
-      })(sampleObject)).toBe(false);
+      }).test(sampleObject)).toBe(false);
     });
   });
 
@@ -53,7 +53,7 @@ describe('to-service ruleparser', () => {
     }));
 
     const mappedRules = ruleParser.mapRules(rules);
-    expect(mappedRules.every(tf => tf(sampleObject))).toBe(true);
+    expect(mappedRules.every(tf => tf.test(sampleObject))).toBe(true);
   });
 
   test('failing rules mapped through `mapRules` should fail', () => {
@@ -64,6 +64,36 @@ describe('to-service ruleparser', () => {
     }));
 
     const mappedRules = ruleParser.mapRules(rules);
-    expect(mappedRules.every(tf => !tf(sampleObject))).toBe(true);
+    expect(mappedRules.every(tf => !tf.test(sampleObject))).toBe(true);
+  });
+
+
+  const ruleText = [
+    {
+      rule: ['responseTime', 'lt', 1],
+      text: 'responseTime of 0.315 is less than 1',
+    },
+    {
+      rule: ['responseBody', 'contains', 'i dont promise'],
+      text: 'responseBody of everything will be ok i promise does not contain i dont promise',
+    },
+    {
+      rule: ['responseCode', 'eq', 204],
+      text: 'responseCode of 200 is not equal to 204',
+    },
+  ];
+
+  ruleText.forEach((rule, i) => {
+    test(`expected ruleText ${i}`, () => {
+      const [type, operator, value] = rule.rule;
+
+      const parsedRule = ruleParser.mapRule({
+        type,
+        operator,
+        value,
+      });
+
+      expect(parsedRule.text(sampleObject)).toBe(rule.text);
+    });
   });
 });

--- a/test/unit/notifications/index.test.js
+++ b/test/unit/notifications/index.test.js
@@ -1,0 +1,118 @@
+const notifications = require('./../../../src/notifications');
+
+describe('notifications', () => {
+  test('it should initialize a monitor once', () => {
+    const testMonitor = {
+      id: 1,
+      initialized: false,
+      healthy: false,
+    };
+
+    const testEvent = {
+      healthy: true,
+    };
+
+    let timesCalled = 0;
+
+    const handler = ({ monitor, event }) => {
+      timesCalled += 1;
+
+      expect(monitor).toBe(testMonitor);
+      expect(event).toBe(testEvent);
+
+      expect(timesCalled).toBe(1); // would fail if called twice
+
+      expect(monitor.initialized).toBe(true);
+      expect(monitor.healthy).toBe(true);
+    };
+
+    notifications.emitter.on('initialized', handler);
+
+    // this should trigger init
+    notifications.log(testMonitor, testEvent);
+    // this should not trigger anything
+    notifications.log(testMonitor, testEvent);
+
+    notifications.emitter.removeListener('initialized', handler);
+  });
+
+  test('it should mark monitor as healthy', () => {
+    const testMonitor = {
+      id: 2,
+      initialized: true,
+      healthy: false,
+    };
+
+    const testEvent = {
+      healthy: true,
+    };
+
+    notifications.emitter.once('healthy', ({ monitor, event }) => {
+      expect(monitor).toBe(testMonitor);
+      expect(event).toBe(testEvent);
+
+      expect(monitor.healthy).toBe(true);
+    });
+
+    notifications.log(testMonitor, testEvent);
+  });
+
+  test('it should not mark monitor as healthy', () => {
+    const testMonitor = {
+      id: 2,
+      initialized: true,
+      healthy: true,
+    };
+
+    const testEvent = {
+      healthy: true,
+    };
+
+    const fail = () => expect(false).toBe(true);
+    notifications.emitter.on('healthy', fail);
+
+    notifications.log(testMonitor, testEvent);
+
+    notifications.emitter.removeListener('healthy', fail);
+  });
+
+  test('it should mark monitor as unhealthy', () => {
+    const testMonitor = {
+      id: 2,
+      initialized: true,
+      healthy: true,
+    };
+
+    const testEvent = {
+      healthy: false,
+    };
+
+    notifications.emitter.once('unhealthy', ({ monitor, event }) => {
+      expect(monitor).toBe(testMonitor);
+      expect(event).toBe(testEvent);
+
+      expect(monitor.healthy).toBe(false);
+    });
+
+    notifications.log(testMonitor, testEvent);
+  });
+
+  test('it should not mark monitor as unhealthy', () => {
+    const testMonitor = {
+      id: 2,
+      initialized: true,
+      healthy: false,
+    };
+
+    const testEvent = {
+      healthy: false,
+    };
+
+    const fail = () => expect(false).toBe(true);
+    notifications.emitter.on('unhealthy', fail);
+
+    notifications.log(testMonitor, testEvent);
+
+    notifications.emitter.removeListener('unhealthy', fail);
+  });
+});


### PR DESCRIPTION
Implements a state-change watcher (notifications.log), which can emit the following events:

- `initialized`: a monitor has become healthy for the first time
- `healthy`: a monitor was unhealthy, but is now healthy again
- `unhealthy`: a monitor was healthy, but is now unhealthy

All three events are given the information:

```javascript
{
  monitor: {
    id: 2,
    name: 'test monitor',
    type: 'to-service',
    initialized: false,
    healthy: false,
    interval: 30,
    request: { url: 'http://albinodrought.com', method: 'get' },
  },

  event: {
    type: 'to-service',
    healthy: true,
    time: 1539031565335,
    actions: [
      { passed: true, text: 'error is null' },
      { passed: true, text: 'responseCode is 200'}
    ],
  },
}
```

(of course, varying depending on configured worker and rules)

From this, I think we could generate the notification text depending on which "service" we're sending it from.

Slack:
```
Title: Monitor 'test monitor' has become healthy!
Body: `error is null and responseCode is 200` (insert special Slack timestamp here)
```

Webhook: probably just pass the raw stuff

Email: some formatted email (glhf, shotty not)
Fixes #3 