### PR TITLE
Webhooks and Slack Notifications (merge target feature/3/notification-base)

### DIFF
--- a/src/notifications/providers/index.js
+++ b/src/notifications/providers/index.js
@@ -1,0 +1,22 @@
+const webhook = require('./webhook');
+const slack = require('./slack');
+
+const providers = {
+  webhooks: webhook,
+  slack,
+};
+
+module.exports.mapNotification = ({ type, value }) => providers[type](value);
+
+module.exports.mapNotifications = (notifications) => {
+  const mappedNotifications = [];
+
+  Object.entries(notifications).forEach(([type, values]) => {
+    values.forEach((value) => {
+      const mappedNotification = module.exports.mapNotification({ type, value });
+      mappedNotifications.push(mappedNotification);
+    });
+  });
+
+  return mappedNotifications;
+};

--- a/src/notifications/providers/slack.js
+++ b/src/notifications/providers/slack.js
@@ -1,0 +1,25 @@
+const request = require('request');
+
+module.exports = url => (type, { monitor, event }) => {
+  const title = `${monitor.name} is ${type}!`;
+
+  const attachments = event.actions.map(action => ({
+    color: action.passed ? 'good' : 'danger',
+    fallback: action.text,
+    text: action.text,
+  }));
+
+  return new Promise((resolve) => {
+    request({
+      method: 'POST',
+      url,
+      body: JSON.stringify({
+        text: title,
+        attachments,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }, resolve);
+  });
+};

--- a/src/notifications/providers/slack.js
+++ b/src/notifications/providers/slack.js
@@ -1,4 +1,4 @@
-const request = require('request');
+const checker = require('./../../monitors/to-service/checker');
 
 module.exports = url => (type, { monitor, event }) => {
   const title = `${monitor.name} is ${type}!`;
@@ -9,17 +9,15 @@ module.exports = url => (type, { monitor, event }) => {
     text: action.text,
   }));
 
-  return new Promise((resolve) => {
-    request({
-      method: 'POST',
-      url,
-      body: JSON.stringify({
-        text: title,
-        attachments,
-      }),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    }, resolve);
+  return checker({
+    url,
+    method: 'POST',
+    body: JSON.stringify({
+      text: title,
+      attachments,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
   });
 };

--- a/src/notifications/providers/webhook.js
+++ b/src/notifications/providers/webhook.js
@@ -1,0 +1,21 @@
+const request = require('request');
+
+const sendWebhook = (url, data) => new Promise((resolve) => {
+  console.log('notifying', url);
+  request({
+    method: 'POST',
+    url,
+    body: JSON.stringify(data),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }, resolve);
+});
+
+module.exports = url => (type, data) => sendWebhook(
+  url,
+  {
+    ...data,
+    type,
+  },
+);

--- a/src/notifications/providers/webhook.js
+++ b/src/notifications/providers/webhook.js
@@ -1,16 +1,16 @@
-const request = require('request');
+const checker = require('./../../monitors/to-service/checker');
 
-const sendWebhook = (url, data) => new Promise((resolve) => {
+const sendWebhook = (url, data) => {
   console.log('notifying', url);
-  request({
+  return checker({
     method: 'POST',
     url,
     body: JSON.stringify(data),
     headers: {
       'Content-Type': 'application/json',
     },
-  }, resolve);
-});
+  });
+};
 
 module.exports = url => (type, data) => sendWebhook(
   url,

--- a/src/notifications/sendNotifications.js
+++ b/src/notifications/sendNotifications.js
@@ -1,0 +1,14 @@
+const providers = require('./providers');
+
+const sendNotifications = type => (data) => {
+  const { monitor } = data;
+  const mappedNotifications = providers.mapNotifications(monitor.notifications || {});
+
+  mappedNotifications.forEach(n => n(type, data));
+};
+
+module.exports = (emitter) => {
+  emitter.on('initialized', sendNotifications('initialized'));
+  emitter.on('healthy', sendNotifications('healthy'));
+  emitter.on('unhealthy', sendNotifications('unhealthy'));
+};

--- a/src/runner.js
+++ b/src/runner.js
@@ -5,12 +5,14 @@ const repositoryDebug = require('./monitors/repositoryDebug');
 const notifications = require('./notifications');
 const notificationDebug = require('./notifications/notificationDebug');
 const notificationSaveToRepo = require('./notifications/saveToRepository');
+const notificationsSend = require('./notifications/sendNotifications');
 
 bootstrapToService(repository.emitter);
 repositoryDebug(repository.emitter);
 
 notificationDebug(notifications.emitter);
 notificationSaveToRepo(notifications.emitter);
+notificationsSend(notifications.emitter);
 
 // insert test monitor
 repository.upsertGraph({

--- a/test/integration/notifications/providers/slack.test.js
+++ b/test/integration/notifications/providers/slack.test.js
@@ -1,0 +1,61 @@
+const express = require('express');
+const slack = require('./../../../../src/notifications/providers/slack');
+
+const HOST = 'localhost';
+const PORT = 10086;
+const BASE = `http://${HOST}:${PORT}`;
+
+describe('slack notification provider', () => {
+  let server;
+  let socket;
+
+  beforeEach((done) => {
+    server = express();
+
+    socket = server.listen(PORT, done);
+  });
+
+  afterEach((done) => {
+    if (socket) {
+      socket.close(done);
+    }
+
+    server = undefined;
+    socket = undefined;
+  });
+
+  test('kitchen sink', (done) => {
+    server.use(express.json());
+    server.post('/services/OOGA/BOOGA/BOOGITY', (req, res) => {
+      expect(req.body).toEqual({
+        text: 'test-monitor is unhealthy!',
+        attachments: [
+          {
+            color: 'good',
+            fallback: 'error is null',
+            text: 'error is null',
+          },
+          {
+            color: 'danger',
+            fallback: 'responseCode is not equal to 200',
+            text: 'responseCode is not equal to 200',
+          },
+        ],
+      });
+      res.send('', 204);
+    });
+
+    slack(`${BASE}/services/OOGA/BOOGA/BOOGITY`)('unhealthy', {
+      monitor: { name: 'test-monitor' },
+      event: {
+        actions: [
+          { passed: true, text: 'error is null' },
+          { passed: false, text: 'responseCode is not equal to 200' },
+        ],
+      },
+    }).then(({ statusCode }) => {
+      expect(statusCode).toBe(204);
+      done();
+    });
+  });
+});

--- a/test/integration/notifications/providers/webhook.test.js
+++ b/test/integration/notifications/providers/webhook.test.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const webhook = require('./../../../../src/notifications/providers/webhook');
+
+const HOST = 'localhost';
+const PORT = 10087;
+const BASE = `http://${HOST}:${PORT}`;
+
+describe('slack notification provider', () => {
+  let server;
+  let socket;
+
+  beforeEach((done) => {
+    server = express();
+
+    socket = server.listen(PORT, done);
+  });
+
+  afterEach((done) => {
+    if (socket) {
+      socket.close(done);
+    }
+
+    server = undefined;
+    socket = undefined;
+  });
+
+  test('kitchen sink', (done) => {
+    server.use(express.json());
+    server.post('/webhook', (req, res) => {
+      expect(req.body).toEqual({
+        monitor: { name: 'test-monitor' },
+        event: {
+          actions: [
+            { passed: true, text: 'error is null' },
+            { passed: false, text: 'responseCode is not equal to 200' },
+          ],
+        },
+        type: 'unhealthy',
+      });
+      res.send('', 204);
+    });
+
+    webhook(`${BASE}/webhook`)('unhealthy', {
+      monitor: { name: 'test-monitor' },
+      event: {
+        actions: [
+          { passed: true, text: 'error is null' },
+          { passed: false, text: 'responseCode is not equal to 200' },
+        ],
+      },
+    }).then(({ statusCode }) => {
+      expect(statusCode).toBe(204);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Enables POSTing updates via Slack or Webhooks by specifying them in the monitor:

```javascript
{
  name: 'test monitor',
  type: 'to-service',
  initialized: false, // if monitor was ever healhy
  healthy: false, // current health state
  interval: 30,
  request: {
    url: 'http://albinodrought.com',
    method: 'get',
  },
  notifications: {
    webhooks: [
      'http://localhost:6969/something-happened',
    ],
    slack: [
      'https://hooks.slack.com/services/OOGA/BOOGA/BOOGITY',
    ],
  },
}
```

Will post the following information to the webhook:

```json
{
  "monitor": {
    "name": "test monitor",
    "type": "to-service",
    "initialized": true,
    "healthy": true,
    "interval": 30,
    "request": {
      "url": "http://albinodrought.com",
      "method": "get"
    },
    "id": 2
  },
  "event": {
    "type": "to-service",
    "healthy": true,
    "time": 1539034171837,
    "actions": [
      {
        "passed": true,
        "text": "error is null"
      }
    ]
  },
  "type": "initialized"
}
```

and the following message to Slack:

![image](https://user-images.githubusercontent.com/852873/46635996-38091c00-cb0b-11e8-8eb9-7ddaec6b5cfc.png)

(beautiful right?)