### PR TITLE
Use a real database for persisting health checks

### DIFF
--- a/src/database/migrations/20181023203657_add_checks_table.js
+++ b/src/database/migrations/20181023203657_add_checks_table.js
@@ -1,0 +1,26 @@
+
+exports.up = knex => knex.schema.createTable('checks', (table) => {
+  table.increments().primary();
+
+  // a check can belong to a user
+  table.integer('user_id').unsigned().nullable();
+  table.foreign('user_id').onDelete('cascade');
+
+  // a check can have a human-readable name
+  table.string('name');
+  // a check has a type ("to-service", "from-service")
+  table.string('type').notNullable();
+
+  // if true, the check has been healthy at least once
+  table.boolean('initialized').default(false);
+  // if true, the check is currently healthy
+  table.boolean('healthy').default(false);
+
+  // the interval, in seconds, of how often to send to-service checks
+  table.integer('interval').unsigned().default(30);
+
+  // the request to send.
+  table.json('request');
+});
+
+exports.down = knex => knex.schema.dropTable('checks');

--- a/src/database/migrations/20181023211147_check_notifications.js
+++ b/src/database/migrations/20181023211147_check_notifications.js
@@ -1,0 +1,8 @@
+
+exports.up = knex => knex.schema.table('checks', (table) => {
+  table.json('notifications');
+});
+
+exports.down = knex => knex.schema.table('checks', (table) => {
+  table.dropColumn('notifications');
+});

--- a/src/database/models/check.js
+++ b/src/database/models/check.js
@@ -1,0 +1,29 @@
+const { Model } = require('objection');
+
+class Check extends Model {
+  static get tableName() {
+    return 'checks';
+  }
+
+  // for input validation
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: [
+        'name',
+        'type',
+      ],
+
+      properties: {
+        id: { type: 'integer' },
+        name: { type: 'string', minLength: 1, maxLength: 255 },
+        type: { type: 'string', minLength: 1, maxLength: 255 },
+        initialized: { type: 'boolean' },
+        healthy: { type: 'boolean' },
+        request: { type: 'object' },
+      },
+    };
+  }
+}
+
+module.exports = Check;

--- a/src/database/models/check.js
+++ b/src/database/models/check.js
@@ -21,6 +21,7 @@ class Check extends Model {
         initialized: { type: 'boolean' },
         healthy: { type: 'boolean' },
         request: { type: 'object' },
+        notifications: { type: 'object' },
       },
     };
   }

--- a/src/runner.js
+++ b/src/runner.js
@@ -14,15 +14,32 @@ notificationDebug(notifications.emitter);
 notificationSaveToRepo(notifications.emitter);
 notificationsSend(notifications.emitter);
 
-// insert test monitor
-repository.upsertGraph({
-  name: 'test monitor',
-  type: 'to-service',
-  initialized: false, // if monitor was ever healhy
-  healthy: false, // current health state
-  interval: 30,
-  request: {
-    url: 'http://albinodrought.com',
-    method: 'get',
-  },
-});
+module.exports = async () => {
+  const things = await repository.all();
+
+  if (things.length) {
+    things.forEach((thing) => {
+      // beautiful hack to rejiggle listeners
+      // boots `setInterval` calls for existing resources
+      repository.emitter.emit('update', thing);
+    });
+  } else {
+    // insert test monitor
+    repository.upsertGraph({
+      name: 'test monitor',
+      type: 'to-service',
+      initialized: false, // if monitor was ever healhy
+      healthy: false, // current health state
+      interval: 30,
+      request: {
+        url: 'http://albinodrought.com',
+        method: 'get',
+      },
+      notifications: {
+        webhooks: [
+          'http://albinodrought.com/hello',
+        ],
+      },
+    });
+  }
+};

--- a/src/server.js
+++ b/src/server.js
@@ -17,6 +17,8 @@ const authRouter = require('./routes/auth');
 
 const { PORT, CLIENT_ORIGIN } = require('./config/server');
 
+const runner = require('./runner');
+
 const app = express();
 
 // set up Passport strategies
@@ -81,6 +83,8 @@ if (require.main === module) {
   app
     .listen(PORT, function () {
       console.info(`Server listening on ${this.address().port}`);
+      // hack to bootstrap local queue worker
+      runner();
     })
     .on('error', (err) => {
       console.error(err);


### PR DESCRIPTION
Adds a `checks` database to replace the previous in-memory datastore and updates the previously-existing repository """interface""" to work with it.

Fixes #28 